### PR TITLE
Wasm build fixes

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -310,11 +310,11 @@ pub const Application = struct {
                 .file_dialogs = app.features.file_dialogs,
             };
 
-            if (features.code_editor and (platform == .web or platform == .android or platform == .desktop)) {
+            if (features.code_editor and (platform == .android or platform == .desktop)) {
                 features.code_editor = false;
                 logger.warn("Disabling unsupported feature 'code_editor' for platform {s}", .{@tagName(platform)});
             }
-            if (features.file_dialogs and (platform == .web or platform == .android or platform == .desktop)) {
+            if (features.file_dialogs and (platform == .android or platform == .desktop)) {
                 features.file_dialogs = false;
                 logger.warn("Disabling unsupported feature 'file_dialogs' for platform {s}", .{@tagName(platform)});
             }

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -310,11 +310,11 @@ pub const Application = struct {
                 .file_dialogs = app.features.file_dialogs,
             };
 
-            if (features.code_editor and (platform == .web or platform == .android)) {
+            if (features.code_editor and (platform == .web or platform == .android or platform == .desktop)) {
                 features.code_editor = false;
                 logger.warn("Disabling unsupported feature 'code_editor' for platform {s}", .{@tagName(platform)});
             }
-            if (features.file_dialogs and (platform == .web or platform == .android)) {
+            if (features.file_dialogs and (platform == .web or platform == .android or platform == .desktop)) {
                 features.file_dialogs = false;
                 logger.warn("Disabling unsupported feature 'file_dialogs' for platform {s}", .{@tagName(platform)});
             }
@@ -494,6 +494,7 @@ pub const AppCompilation = struct {
         return switch (comp.data) {
             .desktop => |step| step.run(),
             .web => |step| blk: {
+                step.rdynamic = true;
                 step.install();
 
                 const serve = comp.sdk.dummy_server.run();

--- a/Sdk.zig
+++ b/Sdk.zig
@@ -310,11 +310,11 @@ pub const Application = struct {
                 .file_dialogs = app.features.file_dialogs,
             };
 
-            if (features.code_editor and (platform == .android or platform == .desktop)) {
+            if (features.code_editor and (platform == .web or platform == .android)) {
                 features.code_editor = false;
                 logger.warn("Disabling unsupported feature 'code_editor' for platform {s}", .{@tagName(platform)});
             }
-            if (features.file_dialogs and (platform == .android or platform == .desktop)) {
+            if (features.file_dialogs and (platform == .web or platform == .android)) {
                 features.file_dialogs = false;
                 logger.warn("Disabling unsupported feature 'file_dialogs' for platform {s}", .{@tagName(platform)});
             }

--- a/build.zig
+++ b/build.zig
@@ -91,18 +91,18 @@ pub fn build(b: *std.build.Builder) !void {
 
     // Build wasm application
     // TODO: Reinclude when https://github.com/llvm/llvm-project/issues/58557 is fixed.
-    // {
-    //     const wasm_build = app.compileFor(.web);
-    //     wasm_build.install();
+    {
+        const wasm_build = app.compileFor(.web);
+        wasm_build.install();
 
-    //     const serve = wasm_build.run();
+        const serve = wasm_build.run();
 
-    //     const build_step = b.step("build-wasm", "Builds the wasm app and installs it.");
-    //     build_step.dependOn(wasm_build.install_step.?);
+        const build_step = b.step("build-wasm", "Builds the wasm app and installs it.");
+        build_step.dependOn(wasm_build.install_step.?);
 
-    //     const run_step = b.step("run-wasm", "Serves the wasm app");
-    //     run_step.dependOn(&serve.step);
-    // }
+        const run_step = b.step("run-wasm", "Serves the wasm app");
+        run_step.dependOn(&serve.step);
+    }
 
     if (enable_android) {
         const android_build = app.compileFor(.android);

--- a/www/zero-graphics.js
+++ b/www/zero-graphics.js
@@ -1282,9 +1282,13 @@ createWebGlModule(canvas_element, getInstance, stop_fn) {
       throw 'uniformMatrix2fv not implemented yet'
     }
     ,
-        uniformMatrix3fv() {
-      // extern fn uniformMatrix3fv (_location: GLint, _count: GLsizei, _transpose: GLboolean, _value: [*c]const GLfloat) void;
-      throw 'uniformMatrix3fv not implemented yet'
+        uniformMatrix3fv(location_id, data_len, transpose, data_ptr) {
+      const floats = new Float32Array(
+          getMemory().buffer,
+          data_ptr,
+          data_len * 12 
+      )
+      gl.uniformMatrix3fv(glUniformLocations[location_id], transpose, floats)
     }
     ,
         validateProgram() {


### PR DESCRIPTION
Re-enable wasm build
Export wasm symbols with rdynamic=true
Skip file code_editor and _file_dialog for wasm builds as they're not building successfully
Add missing uniformMatrix3fv() to JavaScript

Required zigimg patches are at https://github.com/ringtailsoftware/zigimg/tree/wasm_fixes