### PR TITLE
Fix zero-init's build template for wasm exports

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -376,7 +376,7 @@ pub const Application = struct {
                     .abi = .musl,
                 });
                 exe.addPackage(build_options);
-
+                exe.rdynamic = true;
                 app.prepareExe(exe, app_pkg, features, platform);
 
                 return app.createCompilation(.{
@@ -494,7 +494,6 @@ pub const AppCompilation = struct {
         return switch (comp.data) {
             .desktop => |step| step.run(),
             .web => |step| blk: {
-                step.rdynamic = true;
                 step.install();
 
                 const serve = comp.sdk.dummy_server.run();

--- a/tools/zero-init/template/build.zig
+++ b/tools/zero-init/template/build.zig
@@ -31,6 +31,11 @@ pub fn build(b: *std.build.Builder) !void {
     // Build wasm application
     {
         const wasm_build = app.compileFor(.web);
+        switch (wasm_build.data) {
+            .web => |step| {
+                step.rdynamic = true;
+            }, else => {},
+        }
         wasm_build.install();
     }
 

--- a/tools/zero-init/template/build.zig
+++ b/tools/zero-init/template/build.zig
@@ -31,11 +31,6 @@ pub fn build(b: *std.build.Builder) !void {
     // Build wasm application
     {
         const wasm_build = app.compileFor(.web);
-        switch (wasm_build.data) {
-            .web => |step| {
-                step.rdynamic = true;
-            }, else => {},
-        }
         wasm_build.install();
     }
 


### PR DESCRIPTION
Adds rdynamic=true to the build template