### PR TITLE
2D rotation support for sprites/textured quads

### DIFF
--- a/Sdk.zig
+++ b/Sdk.zig
@@ -376,7 +376,7 @@ pub const Application = struct {
                     .abi = .musl,
                 });
                 exe.addPackage(build_options);
-
+                exe.rdynamic = true;
                 app.prepareExe(exe, app_pkg, features, platform);
 
                 return app.createCompilation(.{
@@ -494,7 +494,6 @@ pub const AppCompilation = struct {
         return switch (comp.data) {
             .desktop => |step| step.run(),
             .web => |step| blk: {
-                step.rdynamic = true;
                 step.install();
 
                 const serve = comp.sdk.dummy_server.run();

--- a/src/rendering/Renderer2D.zig
+++ b/src/rendering/Renderer2D.zig
@@ -693,7 +693,8 @@ pub fn render(self: Self, screen_size: Size) void {
 
 /// Appends a set of triangles to the renderer with the given `texture`.
 pub fn appendTriangles(self: *Self, texture: ?*ResourceManager.Texture, triangles: []const [3]Vertex, rot_radians:?f32, rot_about:?Point) DrawError!void {
-    const draw_call = if (self.draw_calls.items.len == 0 or self.draw_calls.items[self.draw_calls.items.len - 1] != .draw_vertices or self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.texture != texture) blk: {
+    const draw_call = if (self.draw_calls.items.len == 0 or self.draw_calls.items[self.draw_calls.items.len - 1] != .draw_vertices or self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.texture != texture or (!std.meta.eql(self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.rot_radians, rot_radians)) or (!std.meta.eql(self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.rot_about, rot_about))
+    ) blk: {
         const dc = try self.draw_calls.addOne();
         dc.* = DrawCall{
             .draw_vertices = DrawVertices{

--- a/src/rendering/Renderer2D.zig
+++ b/src/rendering/Renderer2D.zig
@@ -691,9 +691,27 @@ pub fn render(self: Self, screen_size: Size) void {
     }
 }
 
+fn cmpRotation(rot_radians_a:?f32, rot_about_a:?Point, rot_radians_b:?f32, rot_about_b:?Point) bool {
+    const rotationThreshold = 0.05;
+
+    // all null
+    if (rot_radians_a == null and rot_radians_b == null and rot_about_a == null and rot_about_b == null) {
+        return true;
+    }
+
+    // only some null
+    if (rot_radians_a == null or rot_radians_b == null or rot_about_a == null or rot_about_b == null) {
+        return false;
+    }
+
+    const rot_about_same = rot_about_a.?.x == rot_about_b.?.x and rot_about_a.?.y == rot_about_b.?.y;
+    const rot_radians_same = std.math.approxEqAbs(f32, rot_radians_a.?, rot_radians_b.?, rotationThreshold);
+    return rot_about_same and rot_radians_same;
+}
+
 /// Appends a set of triangles to the renderer with the given `texture`.
 pub fn appendTriangles(self: *Self, texture: ?*ResourceManager.Texture, triangles: []const [3]Vertex, rot_radians:?f32, rot_about:?Point) DrawError!void {
-    const draw_call = if (self.draw_calls.items.len == 0 or self.draw_calls.items[self.draw_calls.items.len - 1] != .draw_vertices or self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.texture != texture or (!std.meta.eql(self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.rot_radians, rot_radians)) or (!std.meta.eql(self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.rot_about, rot_about))
+    const draw_call = if (self.draw_calls.items.len == 0 or self.draw_calls.items[self.draw_calls.items.len - 1] != .draw_vertices or self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.texture != texture or !cmpRotation(self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.rot_radians, self.draw_calls.items[self.draw_calls.items.len - 1].draw_vertices.rot_about, rot_radians, rot_about)
     ) blk: {
         const dc = try self.draw_calls.addOne();
         dc.* = DrawCall{

--- a/tools/zero-init/template/build.zig
+++ b/tools/zero-init/template/build.zig
@@ -31,6 +31,11 @@ pub fn build(b: *std.build.Builder) !void {
     // Build wasm application
     {
         const wasm_build = app.compileFor(.web);
+        switch (wasm_build.data) {
+            .web => |step| {
+                step.rdynamic = true;
+            }, else => {},
+        }
         wasm_build.install();
     }
 

--- a/tools/zero-init/template/build.zig
+++ b/tools/zero-init/template/build.zig
@@ -31,11 +31,6 @@ pub fn build(b: *std.build.Builder) !void {
     // Build wasm application
     {
         const wasm_build = app.compileFor(.web);
-        switch (wasm_build.data) {
-            .web => |step| {
-                step.rdynamic = true;
-            }, else => {},
-        }
         wasm_build.install();
     }
 

--- a/www/zero-graphics.js
+++ b/www/zero-graphics.js
@@ -1232,9 +1232,13 @@ createWebGlModule(canvas_element, getInstance, stop_fn) {
       throw 'uniform2f not implemented yet'
     }
     ,
-        uniform2fv() {
-      // extern fn uniform2fv (_location: GLint, _count: GLsizei, _value: [*c]const GLfloat) void;
-      throw 'uniform2fv not implemented yet'
+        uniform2fv(location_id, count, data_ptr) {
+        const floats = new Float32Array(
+          getMemory().buffer,
+          data_ptr,
+          count * 2
+      )
+      gl.uniform2fv(glUniformLocations[location_id], floats);
     }
     ,
         uniform2iv() {


### PR DESCRIPTION
Add support for rotated 2D textured quads.
Adds drawPartialTextureRot() and drawPartialTexturePixelsRot(), both take an angle in radians and a Point to rotate about.
Existing API is not affected.
Rotation is performed in the vertex shader via two new uniforms, "rotateAngle" and "rotateAbout".
Support added to wasm for uniform2fv()